### PR TITLE
Correct readLinearAcceleration function

### DIFF
--- a/src/NineAxesMotion.cpp
+++ b/src/NineAxesMotion.cpp
@@ -1091,9 +1091,9 @@ void NineAxesMotion::readLinearAcceleration(float& x, float& y, float& z)
 	{
 		updateLinearAccel();
 	}
-	x = gravAccelData.x;
-	y = gravAccelData.y;
-	z = gravAccelData.z;
+	x = linearAccelData.x;
+	y = linearAccelData.y;
+	z = linearAccelData.z;
 }
 
 float NineAxesMotion::readLinearAcceleration(int axis)


### PR DESCRIPTION
> [<img alt="septatrix" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/septatrix) **Authored by [septatrix](https://github.com/septatrix)**
_<time datetime="2019-05-04T14:34:25Z" title="Saturday, May 4th 2019, 4:34:25 pm +02:00">May 4, 2019</time>_

---

changed typo to give back correct information like the other methods which read linearAccelData