### PR TITLE
fixes #4 by parameterising interrupt and reset pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ determine offsets. Follow the instructions below to calibrate your sensor.
 
  - Magnetometer: Move the magnetometer in a large 8 like pattern a few times
 	gently.
+
+Setting up pins
+-----------
+
+See the declaration for initSensor in NineAxesMotion.h
+Ensure you have correctly configured the Interrupt and Reset pins. Modern boards default to Interrupt Pin = 2 and Reset Pin = 7, although your board may be jumpered differently. The most probable alternative pins are Interrupt Pin = 4 and Reset Pin = 3. Consult your shield and observe how these tracks are jumpered on your particular setup.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=9 Axes Motion
-version=1.1.0
+version=1.2.0
 author=Bosch Sensortec GmbH
 maintainer=Arduino <swdev@arduino.org>
 sentence=Arduino 9 Axes Motion Shield Library

--- a/src/NineAxesMotion.cpp
+++ b/src/NineAxesMotion.cpp
@@ -65,11 +65,17 @@ NineAxesMotion::NineAxesMotion()
 
 /*******************************************************************************************
 *Description: Function with the bare minimum initialization
-*Input Parameters: None
+*Input Parameters:
+	unsigned int address: I2C address of the BNO055. Default 0x28
+	int int_pin: GPIO to receive the Interrupt from the BNO055 for the Arduino Uno (Interrupt is visible on the INT LED on the Shield)
+	int reset_pin: GPIO to reset the BNO055 (RESET pin has to be HIGH for the BNO055 to operate)
 *Return Parameter: None
 *******************************************************************************************/
-void NineAxesMotion::initSensor(unsigned int address)
+void NineAxesMotion::initSensor(unsigned int address, int int_pin, int reset_pin)
 {
+	INT_PIN = int_pin;
+	RESET_PIN = reset_pin;
+
 	//Initialize the GPIO peripheral
 	pinMode(INT_PIN, INPUT_PULLUP);		//Configure Interrupt pin
 	pinMode(RESET_PIN, OUTPUT);			//Configure Reset pin

--- a/src/NineAxesMotion.h
+++ b/src/NineAxesMotion.h
@@ -92,17 +92,16 @@ struct bno055_accel_stat_t {
 	uint8_t powerMode;	//Power mode: Normal - Deep suspend
 };
 
-//GPIO pins used for controlling the Sensor
-#define RESET_PIN		4		//GPIO to reset the BNO055 (RESET pin has to be HIGH for the BNO055 to operate)
+//GPIO to reset the BNO055 (RESET pin has to be HIGH for the BNO055 to operate)
+int RESET_PIN = 7; // 7 or 4 are most likely candidate pins
 
-#if defined(__AVR_ATmega32U4__) //Arduino Yun and Leonardo
-#define INT_PIN			4		//GPIO to receive the Interrupt from the BNO055 for the Arduino Uno(Interrupt is visible on the INT LED on the Shield)
-#elif defined(ARDUINO_ARCH_SAM)   //INT_PIN is the interrupt number not the interrupt pin
-#define INT_PIN			2
-#elif defined(ARDUINO_ARCH_SAMD)
-#define INT_PIN 		7
+//GPIO to receive the Interrupt from the BNO055 (Interrupt is visible on the INT LED on the Shield)
+#if defined(__AVR_ATmega32U4__) //Arduino Yun and Leonardo have I2C shared with pins 2 and 3
+int INT_PIN	= 7;
+#elif defined(ARDUINO_SAMD)
+int INT_PIN	= 7;				// Older SAMD boards have NMI mapped on pin 2
 #else
-#define INT_PIN			0
+int INT_PIN	= 2;
 #endif
 
 #define ENABLE			1		//For use in function parameters
@@ -147,10 +146,13 @@ public:
 
 	/*******************************************************************************************
 	*Description: Function with the bare minimum initialization
-	*Input Parameters: None
+	*Input Parameters:
+		unsigned int address: I2C address of the BNO055. Default 0x28
+		int int_pin: GPIO to receive the Interrupt from the BNO055 for the Arduino Uno (Interrupt is visible on the INT LED on the Shield)
+		int reset_pin: GPIO to reset the BNO055 (RESET pin has to be HIGH for the BNO055 to operate)
 	*Return Parameter: None
 	*******************************************************************************************/
-	void initSensor(unsigned int address = 0x28);
+	void initSensor(unsigned int address = 0x28, int int_pin = 2, int reset_pin = 7);
 
 	/*******************************************************************************************
 	*Description: This function is used to reset the BNO055


### PR DESCRIPTION
> [<img alt="trullock" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/trullock) **Authored by [trullock](https://github.com/trullock)**
_<time datetime="2019-11-18T17:01:32Z" title="Monday, November 18th 2019, 6:01:32 pm +01:00">Nov 18, 2019</time>_
_Closed <time datetime="2019-11-18T17:26:00Z" title="Monday, November 18th 2019, 6:26:00 pm +01:00">Nov 18, 2019</time>_
---

Fixed misleading comments
Fixed initSensor parameter comments
Made reset and int pins parameterisable
Set them to defaults which actually work